### PR TITLE
fix: AudioToSilkCoder.connect throw

### DIFF
--- a/src/main/java/io/github/kasukusakura/silkcodec/AudioToSilkCoder.java
+++ b/src/main/java/io/github/kasukusakura/silkcodec/AudioToSilkCoder.java
@@ -99,8 +99,8 @@ public class AudioToSilkCoder {
                 if (NativeBridge.DEB) {
                     System.out.println("[P-INT] shutdown");
                 }
-            } catch (Throwable throwable) {
-                errorLog(throwable);
+            } catch (CoderException exception) {
+                throw new IOException("Cannot encode Hz: " + hz, exception);
             }
         } catch (Throwable throwable) {
             try {
@@ -115,6 +115,7 @@ public class AudioToSilkCoder {
                     throwable.addSuppressed(ioe);
                 }
             }
+            throw throwable;
         }
     }
 


### PR DESCRIPTION
将 catch 后处理的异常重新 throw 