### PR TITLE
feat: 22050 Hz and warn

### DIFF
--- a/native/src/silk/SKP_Silk_enc_API.c
+++ b/native/src/silk/SKP_Silk_enc_API.c
@@ -124,6 +124,7 @@ SKP_int SKP_Silk_SDK_Encode(
     if( ( ( encControl->API_sampleRate        !=  8000 ) &&
           ( encControl->API_sampleRate        != 12000 ) &&
           ( encControl->API_sampleRate        != 16000 ) &&
+          ( encControl->API_sampleRate        != 22050 ) &&
           ( encControl->API_sampleRate        != 24000 ) && 
           ( encControl->API_sampleRate        != 32000 ) &&
           ( encControl->API_sampleRate        != 44100 ) &&

--- a/src/main/java/io/github/kasukusakura/silkcodec/AudioToSilkCoder.java
+++ b/src/main/java/io/github/kasukusakura/silkcodec/AudioToSilkCoder.java
@@ -82,6 +82,11 @@ public class AudioToSilkCoder {
             if (hz == 0) {
                 throw new IOException("Cannot find Hz");
             }
+            if (hz == 22050) {
+                if (!Boolean.getBoolean("silk-codec.rate-check-ignore")) {
+                    throw new IllegalArgumentException("22050 Hz is not supported. If you need to ignore this check, please set `silk-codec.rate-check-ignore=true`");
+                }
+            }
             threadPool.execute(() -> {
                 try {
                     // drop error input


### PR DESCRIPTION
折衷一点？

对 `22050 Hz` 进行支持，但默认情况下依旧不允许使用
需要设置 `silk-codec.rate-check-ignore=true`

PS: 我老是想弄 `22050 Hz` 是因为 Vits 框架弄出来的音频好像固定只有 `22050 Hz`， 例如 https://github.com/CjangCjengh/MoeGoe